### PR TITLE
Feature/response struct

### DIFF
--- a/examples/with_router.re
+++ b/examples/with_router.re
@@ -2,15 +2,17 @@ Fmt_tty.setup_std_outputs();
 Logs.set_level(Some(Logs.Info));
 Logs.set_reporter(Logs_fmt.reporter());
 
-let root_handler = _request => Morph_core.Response.text("Hello world!");
+let root_handler = _request =>
+  Morph_core.Response.text("Hello world!", Morph_core.Response.empty());
 
 let greet_handler = (greeting, _request) => {
-  Morph_core.Response.text("Hello " ++ greeting);
+  Morph_core.Response.text("Hello " ++ greeting, Morph_core.Response.empty());
 };
 
 let static_handler = _request => {
   let path_to_static_file = Sys.getcwd() ++ "/README.md";
-  Morph_core.Response.static(path_to_static_file);
+  Morph_core.Response.empty()
+  |> Morph_core.Response.static(path_to_static_file);
 };
 
 let routes =
@@ -53,7 +55,7 @@ let handler = (request: Morph_core.Request.t) => {
   |> (
     fun
     | Some(res) => res(request)
-    | None => Morph_core.Response.not_found()
+    | None => Morph_core.Response.not_found(Morph_core.Response.empty())
   );
 };
 

--- a/morph_core/src/Response.re
+++ b/morph_core/src/Response.re
@@ -10,76 +10,80 @@ type t = {
   body,
 };
 
+let empty = () => {status: `OK, headers: [], body: String("")};
+
 let make = (~status=`OK, ~headers=[], body) => {status, headers, body};
 
-let ok = (~extra_headers=[], ()) => {
-  let headers = [("content-length", "2"), ...extra_headers];
-
-  make(~status=`OK, ~headers, String("ok")) |> Lwt.return;
+let add_header = (new_header: (string, string), res: t) => {
+  {...res, headers: res.headers @ [new_header]};
 };
 
-let text = (~extra_headers=[], text) => {
+let set_status = (status: Status.t, res: t) => {
+  {...res, status};
+};
+
+let set_body = (body: body, res: t) => {
+  {...res, body};
+};
+
+let ok = (res: t) => {
+  add_header(("Content-length", "2"), res)
+  |> set_status(`OK)
+  |> set_body(String("ok"))
+  |> Lwt.return;
+};
+
+let text = (text, res: t) => {
   let content_length = text |> String.length |> string_of_int;
-  let headers = [("content-length", content_length), ...extra_headers];
-
-  make(~status=`OK, ~headers, String(text)) |> Lwt.return;
+  add_header(("Content-length", content_length), res)
+  |> set_body(String(text))
+  |> Lwt.return;
 };
 
-let json = (~extra_headers=[], json) => {
+let json = (json, res: t) => {
   let content_length = json |> String.length |> string_of_int;
-  let headers = [
-    ("content-type", "application/json"),
-    ("content-length", content_length),
-    ...extra_headers,
-  ];
-
-  make(~status=`OK, ~headers, String(json)) |> Lwt.return;
+  add_header(("Content-type", "application/json"), res)
+  |> add_header(("Content-length", content_length))
+  |> set_body(String(json))
+  |> Lwt.return;
 };
 
-let html = (~extra_headers=[], markup) => {
+let html = (markup, res: t) => {
   let content_length = markup |> String.length |> string_of_int;
-  let headers = [
-    ("content-type", "text/html"),
-    ("content-length", content_length),
-    ...extra_headers,
-  ];
-
-  make(~status=`OK, ~headers, String(markup)) |> Lwt.return;
+  add_header(("Content-type", "text/html"), res)
+  |> add_header(("Content-length", content_length))
+  |> set_body(String(markup))
+  |> Lwt.return;
 };
 
-let redirect = (~extra_headers=?, ~code=303, targetPath) => {
+let redirect = (~code=303, targetPath, res: t) => {
   let content_length = targetPath |> String.length |> string_of_int;
 
-  let constantHeaders = [
-    ("content-length", content_length),
-    ("location", targetPath),
-  ];
-
-  let headers =
-    switch (extra_headers) {
-    | Some(h) => List.concat([constantHeaders, h])
-    | None => constantHeaders
-    };
-
-  make(~status=`Code(code), ~headers, String(targetPath)) |> Lwt.return;
+  add_header(("Content-length", content_length), res)
+  |> add_header(("Location", targetPath))
+  |> set_status(`Code(code))
+  |> set_body(String(targetPath))
+  |> Lwt.return;
 };
 
-let unauthorized = (~extra_headers=[], message) => {
-  let headers = [
-    ("content-length", String.length(message) |> string_of_int),
-    ...extra_headers,
-  ];
-
-  make(~status=`Unauthorized, ~headers, String(message)) |> Lwt.return;
+let unauthorized = (message, res: t) => {
+  add_header(
+    ("Content-length", String.length(message) |> string_of_int),
+    res,
+  )
+  |> set_status(`Unauthorized)
+  |> set_body(String(message))
+  |> Lwt.return;
 };
 
-let not_found = (~extra_headers=[], ~message="Not found", ()) => {
-  let headers = [
+let not_found = (~message="Not found", res: t) => {
+  add_header(
     ("content-length", String.length(message) |> string_of_int),
-    ...extra_headers,
-  ];
-
-  make(~status=`Not_found, ~headers, String(message)) |> Lwt.return;
+    res,
+  )
+  |> set_status(`Not_found)
+  |> set_body(String(message))
+  |> Lwt.return;
 };
 
 let get_file_stream = file_name => {
@@ -89,17 +93,15 @@ let get_file_stream = file_name => {
   Lwt_io.of_unix_fd(fd, ~mode=Lwt_io.Input) |> Lwt_io.read_chars;
 };
 
-let static = (~extra_headers=[], file_path) => {
+let static = (file_path, res: t) => {
   Sys.file_exists(file_path)
     ? {
       let size = Unix.stat(file_path).st_size;
-      let headers = [
-        ("Content-type", Magic_mime.lookup(file_path)),
-        ("Content-length", string_of_int(size)),
-        ...extra_headers,
-      ];
       let stream = get_file_stream(file_path);
-      make(~status=`OK, ~headers, Stream(stream)) |> Lwt.return;
+      add_header(("Content-type", Magic_mime.lookup(file_path)), res)
+      |> add_header(("Content-length", string_of_int(size)))
+      |> set_body(Stream(stream))
+      |> Lwt.return;
     }
-    : not_found(~extra_headers, ~message="File does not exist", ());
+    : not_found(~message="File does not exist", res);
 };

--- a/morph_core/src/Response.rei
+++ b/morph_core/src/Response.rei
@@ -1,6 +1,6 @@
 /**
 [headers] is represented as a list of (string, string) tuples.
-  */
+*/
 type headers = list((string, string));
 
 /**
@@ -25,42 +25,61 @@ type t = {
 let make: (~status: Status.t=?, ~headers: headers=?, body) => t;
 
 /**
-[ok extra_headers unit] is a conventience function to return a 200 OK response.
+[empty unit] creates an empty response.
 */
-let ok: (~extra_headers: headers=?, unit) => Lwt.t(t);
+let empty: unit => t;
 
 /**
-[text extra_headers text] is a conventience function to return a text response.
+[add_header header response] returns a copy of t of response with the header tuple added.
 */
-let text: (~extra_headers: headers=?, string) => Lwt.t(t);
+let add_header: ((string, string), t) => t;
 
 /**
-[json extra_headers json] is a conventience function to return a JSON response.
+[set_status status response] returns a copy of t with the given status.
 */
-let json: (~extra_headers: headers=?, string) => Lwt.t(t);
+let set_status: (Status.t, t) => t;
 
 /**
-[html extra_headers markup] is a conventience function to return a HTML response.
+[set_body body response] returns a copy of t with the given body.
 */
-let html: (~extra_headers: headers=?, string) => Lwt.t(t);
+let set_body: (body, t) => t;
 
 /**
-[redirect extra_headers code target] is a conventience function to create a redirect response.
+[ok response] is a conventience function to return a 200 OK response.
 */
-let redirect: (~extra_headers: headers=?, ~code: int=?, string) => Lwt.t(t);
+let ok: t => Lwt.t(t);
 
 /**
-[unauthorized extra_headers message] is a conventience function to return a unauthorized response.
+[text text response] is a conventience function to return a text response.
 */
-let unauthorized: (~extra_headers: headers=?, string) => Lwt.t(t);
+let text: (string, t) => Lwt.t(t);
 
 /**
-[not_found extra_headers message unit] is a conventience function to return a 404 Not found response.
+[json json response] is a conventience function to return a JSON response.
 */
-let not_found:
-  (~extra_headers: headers=?, ~message: string=?, unit) => Lwt.t(t);
+let json: (string, t) => Lwt.t(t);
 
 /**
- [static extra_headers file_path] is a convenience function to return a 200 response with the contents of a static file.  If the file does not exist a 404 Not found response is sent instead.
+[html markup response] is a conventience function to return a HTML response.
+*/
+let html: (string, t) => Lwt.t(t);
+
+/**
+[redirect code target response] is a conventience function to create a redirect response.
+*/
+let redirect: (~code: int=?, string, t) => Lwt.t(t);
+
+/**
+[unauthorized message response] is a conventience function to return a unauthorized response.
+*/
+let unauthorized: (string, t) => Lwt.t(t);
+
+/**
+[not_found message response] is a conventience function to return a 404 Not found response.
+*/
+let not_found: (~message: string=?, t) => Lwt.t(t);
+
+/**
+ [static file_path response] is a convenience function to return a 200 response with the contents of a static file.  If the file does not exist a 404 Not found response is sent instead.
  */
-let static: (~extra_headers: headers=?, string) => Lwt.t(t);
+let static: (string, t) => Lwt.t(t);


### PR DESCRIPTION
Updated all of the `Morph_core.Response` helper functions to be in `t` last format.  Also added helpers for updating a `t` to make the api work nicely together.

for example:
```ocaml
Morph_core.Response.empty()
|> Morph_core.Response.set_status(`Code(201))
|> Morph_core.Response.json(json_data);
```