### PR TITLE
Change the type of body to be polymorphic

### DIFF
--- a/morph/src/Respond.re
+++ b/morph/src/Respond.re
@@ -9,10 +9,10 @@ let respond =
       response: Morph_core.Response.t,
     ) => {
   switch (response.body) {
-  | String(body) =>
+  | `String(body) =>
     let () = respond_with_string(request_descriptor, http_response, body);
     ();
-  | Stream(stream) =>
+  | `Stream(stream) =>
     let response_body =
       respond_with_streaming(request_descriptor, http_response);
     let rec read_stream = () => {

--- a/morph_client/src/Morph_client.re
+++ b/morph_client/src/Morph_client.re
@@ -32,7 +32,7 @@ let read_response = (~notify_finished, response, response_body) => {
         notify_finished,
         Morph_core.Response.{
           status: `OK,
-          body: String(Buffer.contents(body_buffer)),
+          body: `String(Buffer.contents(body_buffer)),
           headers: Httpaf.Headers.to_list(headers),
         },
       );
@@ -65,7 +65,7 @@ let read_response = (~notify_finished, response, response_body) => {
         notify_finished,
         Morph_core.Response.{
           status: from_httpaf_status(status),
-          body: String(Buffer.contents(body_buffer)),
+          body: `String(Buffer.contents(body_buffer)),
           headers: Httpaf.Headers.to_list(headers),
         },
       );

--- a/morph_core/src/Response.re
+++ b/morph_core/src/Response.re
@@ -1,9 +1,6 @@
 type headers = list((string, string));
 
-type body = [
-  | `String(string)
-  | `Stream(Lwt_stream.t(char))
-];
+type body = [ | `String(string) | `Stream(Lwt_stream.t(char))];
 
 type t = {
   status: Status.t,

--- a/morph_core/src/Response.rei
+++ b/morph_core/src/Response.rei
@@ -6,9 +6,10 @@ type headers = list((string, string));
 /**
  [Response.body] variant type structure.  Either a flat [string], or an [Lwt_stream.t(char)].
  */
-type body =
-  | String(string)
-  | Stream(Lwt_stream.t(char));
+type body = [
+  | `String(string)
+  | `Stream(Lwt_stream.t(char))
+];
 
 /**
 The core [Response.t] type

--- a/morph_core/src/Response.rei
+++ b/morph_core/src/Response.rei
@@ -6,10 +6,7 @@ type headers = list((string, string));
 /**
  [Response.body] variant type structure.  Either a flat [string], or an [Lwt_stream.t(char)].
  */
-type body = [
-  | `String(string)
-  | `Stream(Lwt_stream.t(char))
-];
+type body = [ | `String(string) | `Stream(Lwt_stream.t(char))];
 
 /**
 The core [Response.t] type


### PR DESCRIPTION
It's easier to create response bodys this way and in theory someone can extend the body and handle that in a middleware