### PR TITLE
feat(morph_logger): basic implementation

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -117,6 +117,17 @@
   ))
 
 (package
+  (name morph_logger)
+  (depends
+    (ocaml (>= 4.04.2))
+    (dune (>= 1.11))
+    reason
+    lwt
+    mtime
+    logs
+    morph))
+
+(package
   (name morph_test)
   (depends
     (ocaml (>= 4.04.2))

--- a/morph_logger.json
+++ b/morph_logger.json
@@ -1,0 +1,26 @@
+{
+  "name": "@reason-native-web/morph_logger",
+  "version": "0.1.2",
+  "esy": {
+    "build": "dune build -p morph_logger",
+    "buildEnv": {
+      "ODOC_SYNTAX": "re"
+    }
+  },
+  "scripts": {
+    "format": "dune build @fmt --auto-promote"
+  },
+  "dependencies": {
+    "@opam/dune": "*",
+    "@opam/lwt": "*",
+    "@opam/mtime": "*",
+    "@opam/logs": "*",
+    "@reason-native-web/morph": "*",
+    "ocaml": "< 4.09.0",
+    "@esy-ocaml/reason": "*"
+  },
+  "resolutions": {
+    "@reason-native-web/morph": "link:./morph.json"
+  },
+  "devDependencies": {}
+}

--- a/src/morph/src/Headers.re
+++ b/src/morph/src/Headers.re
@@ -1,0 +1,16 @@
+type t = list((string, string));
+
+let empty = [];
+
+let get_header = (key, headers) =>
+  headers
+  |> List.find_opt(((header, _)) =>
+       String.lowercase_ascii(header) == String.lowercase_ascii(key)
+     )
+  |> Utils.map_opt(snd);
+
+let add_header = (new_header, headers) => 
+  headers @ [new_header];
+
+let add_headers = (new_headers, headers: t) =>
+  headers @ new_headers;

--- a/src/morph/src/Headers.rei
+++ b/src/morph/src/Headers.rei
@@ -1,0 +1,9 @@
+type t = list((string, string));
+
+let empty: t;
+
+let get_header: (string, t) => option(string);
+
+let add_header: ((string, string), t) => t;
+
+let add_headers: (list((string, string)), t) => t;

--- a/src/morph/src/Morph.re
+++ b/src/morph/src/Morph.re
@@ -17,3 +17,5 @@ module Response = Response;
 
 module Method = Method;
 module Status = Status;
+
+module Headers = Headers;

--- a/src/morph/src/Morph.rei
+++ b/src/morph/src/Morph.rei
@@ -29,3 +29,5 @@ module Response = Response;
 
 module Method = Method;
 module Status = Status;
+
+module Headers = Headers;

--- a/src/morph/src/Request.re
+++ b/src/morph/src/Request.re
@@ -1,7 +1,7 @@
 type t = {
   target: string,
   meth: Method.t,
-  headers: list((string, string)),
+  headers: Headers.t,
   read_body: unit => Lwt.t(string),
   context: Hmap.t,
 };
@@ -9,7 +9,7 @@ type t = {
 let make =
     (
       ~meth=`GET,
-      ~headers=[],
+      ~headers=Headers.empty,
       ~read_body=() => Lwt.return(""),
       ~context=Hmap.empty,
       target,

--- a/src/morph/src/Request.rei
+++ b/src/morph/src/Request.rei
@@ -1,7 +1,7 @@
 type t = {
   target: string,
   meth: Method.t,
-  headers: list((string, string)),
+  headers: Headers.t,
   read_body: unit => Lwt.t(string),
   context: Hmap.t,
 };
@@ -9,7 +9,7 @@ type t = {
 let make:
   (
     ~meth: Method.t=?,
-    ~headers: list((string, string))=?,
+    ~headers: Headers.t=?,
     ~read_body: unit => Lwt.t(string)=?,
     ~context: Hmap.t=?,
     string

--- a/src/morph/src/Response.rei
+++ b/src/morph/src/Response.rei
@@ -1,9 +1,4 @@
 /**
-[headers] is represented as a list of (string, string) tuples.
-*/
-type headers = list((string, string));
-
-/**
  [Response.body] variant type structure. There are currently 3 types of bodies.
 
  [`String] Use a simple string as body
@@ -26,14 +21,14 @@ The core [Response.t] type
 */
 type t = {
   status: Status.t,
-  headers,
+  headers: Headers.t,
   body,
 };
 
 /**
 [make status headers body] creates a response.
 */
-let make: (~status: Status.t=?, ~headers: headers=?, body) => t;
+let make: (~status: Status.t=?, ~headers: Headers.t=?, body) => t;
 
 /**
 [empty t] an empty response, a starting place to compose an http response.
@@ -48,7 +43,7 @@ let add_header: ((string, string), t) => t;
 /**
 [add_header headers response] returns a copy of t of response with the headers added.
 */
-let add_headers: (headers, t) => t;
+let add_headers: (list((string, string)), t) => t;
 
 /**
 [set_status status response] returns a copy of t with the given status.

--- a/src/morph/src/Utils.re
+++ b/src/morph/src/Utils.re
@@ -3,3 +3,9 @@ let map_or = (~default: 'b, fn: 'a => 'b, opt: option('a)) =>
   | Some(value) => fn(value)
   | None => default
   };
+
+let map_opt = (fn: 'a => 'b, opt: option('a)) =>
+  switch(opt) {
+    | None => None
+    | Some(v) => Some(fn(v))
+  };

--- a/src/morph_logger/.npmignore
+++ b/src/morph_logger/.npmignore
@@ -1,0 +1,4 @@
+*.install
+*.merlin
+*.lock
+_esy

--- a/src/morph_logger/src/Morph_logger.re
+++ b/src/morph_logger/src/Morph_logger.re
@@ -1,0 +1,170 @@
+
+let get_or_else = default =>
+  fun
+  | None => default
+  | Some(v) => v;
+
+module Date = {
+  type format =
+    | CLF
+    | ISO
+    | WEB;
+
+  let month_to_string =
+    fun
+    | 0 => "Jan"
+    | 1 => "Feb"
+    | 2 => "Mar"
+    | 3 => "Apr"
+    | 4 => "May"
+    | 5 => "Jun"
+    | 6 => "Jul"
+    | 7 => "Aug"
+    | 8 => "Sep"
+    | 9 => "Oct"
+    | 10 => "Nov"
+    | 11 => "Dec"
+    | _ => "-";
+
+  let day_to_string =
+    fun
+    | 0 => "Sun"
+    | 1 => "Mon"
+    | 2 => "Tue"
+    | 3 => "Wed"
+    | 4 => "Thu"
+    | 5 => "Fri"
+    | 6 => "Sat"
+    | _ => "-";
+
+  let print = (format: format) => {
+    let {tm_sec, tm_min, tm_hour, tm_mday, tm_mon, tm_year, tm_wday, _}: Unix.tm =
+      Unix.gettimeofday() |> Unix.gmtime;
+
+    let pad_digits = v =>
+      v < 10 ? "0" ++ string_of_int(v) : string_of_int(v);
+
+    switch (format) {
+    | ISO =>
+      /* common ISO 8601 date time format (2000-10-10T13:55:36.000Z) */
+      Format.sprintf(
+        "%d-%s-%sT%s:%s:%s.000Z",
+        tm_year + 1900,
+        pad_digits(tm_mon + 1),
+        pad_digits(tm_mday),
+        pad_digits(tm_hour),
+        pad_digits(tm_min),
+        pad_digits(tm_sec),
+      )
+    | CLF =>
+      /* common log format ("10/Oct/2000:13:55:36 +0000") */
+      Format.sprintf(
+        "%s/%s/%d:%s:%s:%s +0000",
+        pad_digits(tm_mday),
+        month_to_string(tm_mon),
+        tm_year + 1900,
+        pad_digits(tm_hour),
+        pad_digits(tm_min),
+        pad_digits(tm_sec),
+      )
+    | WEB =>
+      /* common RFC 1123 date time format (Tue, 10 Oct 2000 13:55:36 GMT) */
+      Format.sprintf(
+        "%s, %s %s %d %s:%s:%s GMT",
+        day_to_string(tm_wday),
+        pad_digits(tm_mday),
+        month_to_string(tm_mon),
+        tm_year + 1900,
+        pad_digits(tm_hour),
+        pad_digits(tm_min),
+        pad_digits(tm_sec),
+      )
+    };
+  };
+};
+
+type t =
+  | Dev
+  | Tiny
+  | Custom(list(token))
+and token =
+  | Url
+  | Status
+  | Method
+  | ResHeader(string)
+  | ReqHeader(string)
+  | S(string)
+  | ResponseTime
+  | UserAgent
+  | Date(Date.format);
+
+
+
+
+let rec print =
+        (
+          ~response_time,
+          ~request: Morph.Request.t,
+          ~response: Morph.Response.t,
+        ) =>
+  fun
+  | Dev =>
+    /* :method :url :status :response-time ms - :res[content-length] */
+    Custom([
+      Method,
+      Url,
+      Status,
+      ResponseTime,
+      S("ms"),
+      S("-"),
+      ResHeader("content-length"),
+    ])
+    |> print(~response_time, ~request, ~response)
+  | Tiny =>
+    /* :method :url :status :res[content-length] - :response-time ms */
+    Custom([
+      Method,
+      Url,
+      Status,
+      ResHeader("content-length"),
+      S("-"),
+      ResponseTime,
+      S("ms"),
+    ])
+    |> print(~response_time, ~request, ~response)
+  | Custom(tokens) =>
+    tokens
+    |> List.map(
+         fun
+         | Url => request.target
+         | Status => response.status |> Morph.Status.to_code |> string_of_int
+         | Method => request.meth |> Morph.Method.to_string
+         | ResHeader(header) =>
+           response.headers |> Morph.Headers.get_header(header) |> get_or_else("-")
+         | ReqHeader(header) =>
+           request.headers |> Morph.Headers.get_header(header) |> get_or_else("-")
+         | S(separator) => separator
+         | ResponseTime => response_time |> string_of_float
+         | UserAgent =>
+           request.headers |> Morph.Headers.get_header("user-agent") |> get_or_else("-")
+         | Date(format) => Date.print(format),
+       )
+    |> List.fold_left((acc, item) => acc ++ " " ++ item, "")
+    |> String.trim;
+
+let logger = (~format: t, service, request: Morph.Request.t) => {
+  let start_request = Mtime_clock.elapsed();
+
+  service(request)
+  |> Lwt.map((response: Morph.Response.t) => {
+       let end_request = Mtime_clock.elapsed();
+       let response_time =
+         Mtime.Span.abs_diff(start_request, end_request) |> Mtime.Span.to_ms;
+
+       Logs.info(m =>
+         m("%s", print(~response_time, ~request, ~response, format))
+       );
+
+       response;
+     });
+};

--- a/src/morph_logger/src/Morph_logger.rei
+++ b/src/morph_logger/src/Morph_logger.rei
@@ -1,0 +1,23 @@
+module Date: {
+  type format =
+    | CLF
+    | ISO
+    | WEB;
+};
+
+type t =
+  | Dev
+  | Tiny
+  | Custom(list(token))
+and token =
+  | Url
+  | Status
+  | Method
+  | ResHeader(string)
+  | ReqHeader(string)
+  | S(string)
+  | ResponseTime
+  | UserAgent
+  | Date(Date.format);
+
+let logger: (~format: t) => Morph.Server.middleware;

--- a/src/morph_logger/src/dune
+++ b/src/morph_logger/src/dune
@@ -1,0 +1,4 @@
+(library
+ (name morph_logger)
+ (public_name morph_logger)
+ (libraries lwt morph mtime mtime.clock.os))


### PR DESCRIPTION
Basic logger implementation based on https://github.com/expressjs/morgan. Not sure if we want this but seams pretty extensible accepting `Custom(list(token))` format allowing us to add more tokens in the future.

I also created `Headers.re` file in `morph` moving all data structure related stuff and providing `get_header` function to easily get single header (used in logger to get request or response headers)

TODO:
- [ ] fix formatting - LSP is failing me :/
- [ ] add basic tests